### PR TITLE
Fix backwards absorb/recoil in MoveMeta

### DIFF
--- a/pokedex/data/csv/move_meta.csv
+++ b/pokedex/data/csv/move_meta.csv
@@ -1,4 +1,4 @@
-move_id,meta_category_id,meta_ailment_id,min_hits,max_hits,min_turns,max_turns,recoil,healing,crit_rate,ailment_chance,flinch_chance,stat_chance
+move_id,meta_category_id,meta_ailment_id,min_hits,max_hits,min_turns,max_turns,drain,healing,crit_rate,ailment_chance,flinch_chance,stat_chance
 1,0,0,,,,,0,0,0,0,0,0
 2,0,0,,,,,0,0,1,0,0,0
 3,0,0,2,5,,,0,0,0,0,0,0

--- a/pokedex/db/tables.py
+++ b/pokedex/db/tables.py
@@ -33,6 +33,7 @@ from functools import partial
 from sqlalchemy import Column, ForeignKey, MetaData, PrimaryKeyConstraint, Table, UniqueConstraint
 from sqlalchemy.ext.declarative import declarative_base, DeclarativeMeta
 from sqlalchemy.ext.associationproxy import association_proxy
+from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import backref, relationship
 from sqlalchemy.orm.session import Session
 from sqlalchemy.orm.interfaces import AttributeExtension
@@ -889,8 +890,8 @@ class MoveMeta(TableBase):
         info=dict(description="Minimum number of turns the user is forced to use the move"))
     max_turns = Column(Integer, nullable=True, index=True,
         info=dict(description="Maximum number of turns the user is forced to use the move"))
-    recoil = Column(Integer, nullable=False, index=True,
-        info=dict(description="Recoil damage, in percent of damage done"))
+    drain = Column(Integer, nullable=False, index=True,
+        info=dict(description="HP drain (if positive) or Recoil damage (if negative), in percent of damage done"))
     healing = Column(Integer, nullable=False, index=True,
         info=dict(description="Healing, in percent of user's max HP"))
     crit_rate = Column(Integer, nullable=False, index=True,
@@ -901,6 +902,11 @@ class MoveMeta(TableBase):
         info=dict(description="Chance to cause flinching, in percent"))
     stat_chance = Column(Integer, nullable=False, index=True,
         info=dict(description="Chance to cause a stat change, in percent"))
+
+    @hybrid_property
+    def recoil(self):
+        "Recoil damage or HP drain; the opposite of `drain`"
+        return -self.drain
 
 class MoveMetaAilment(TableBase):
     u"""Common status ailments moves can inflict on a single Pokémon, including


### PR DESCRIPTION
`MoveMeta.recoil` was negative on recoil moves, but positive on draining moves. Switch that around.
