### PR TITLE
Update Brick Break for its BW effect.

### DIFF
--- a/pokedex/data/csv/move_effect_changelog.csv
+++ b/pokedex/data/csv/move_effect_changelog.csv
@@ -26,3 +26,4 @@ id,effect_id,changed_in_version_group_id
 25,27,8
 26,224,11
 27,255,8
+28,187,11

--- a/pokedex/data/csv/move_effect_changelog_prose.csv
+++ b/pokedex/data/csv/move_effect_changelog_prose.csv
@@ -26,3 +26,4 @@ move_effect_changelog_id,local_language_id,effect
 25,9,Lasts either two or three turns.
 26,9,"If the target is not under the effect of []{move:detect} or []{move:protect}, this move will fail."
 27,9,The user receieves 1/2 of the damage dealt in recoil.
+28,9,The barriers are destroyed even if this move has [no effect]{mechanic:no-effect}.

--- a/pokedex/data/csv/move_effect_prose.csv
+++ b/pokedex/data/csv/move_effect_prose.csv
@@ -593,7 +593,7 @@ Items taken or given away by []{move:covet}, []{move:knock-off}, []{move:switche
 186,9,Inflicts double damage if the user takes damage before attacking this turn.,"Inflicts [regular damage]{mechanic:regular-damage}.  If the target damaged the user this turn and was the last to do so, this move has double power.
 
 []{move:pain-split} does not count as damaging the user."
-187,9,Destroys Reflect and Light Screen.,"Destroys any []{move:light-screen} or []{move:reflect} on the target's side of the [field]{mechanic:field}, then inflicts [regular damage]{mechanic:regular-damage}.  The barriers are destroyed even if this move has [no effect]{mechanic:no-effect}."
+187,9,Destroys Reflect and Light Screen.,"Destroys any []{move:light-screen} or []{move:reflect} on the target's side of the [field]{mechanic:field}, then inflicts [regular damage]{mechanic:regular-damage}."
 188,9,Target sleeps at the end of the next turn.,"Puts the target to [sleep]{mechanic:sleep} at the end of the next turn.  Ignores [accuracy]{mechanic:accuracy} and [evasion]{mechanic:evasion} modifiers.  If the target leaves the [field]{mechanic:field}, this effect is canceled.  If the target has a status effect when this move is used, this move will [fail]{mechanic:fail}.
 
 If the target is protected by []{move:safeguard} when this move is used, this move will [fail]{mechanic:fail}.


### PR DESCRIPTION
Also, Brick Break destroys Reflect and Light Screen even if the target has Substitute, but I'm not sure if it needs to be mentioned.