### PR TITLE
Prevent throwing StopIteration in the wrong place

### DIFF
--- a/pokedex/db/translations.py
+++ b/pokedex/db/translations.py
@@ -377,10 +377,7 @@ def group_by_object(stream):
     Yields ((class name, object ID), (list of messages)) pairs.
     """
     stream = iter(stream)
-    try:
-        current = next(stream)
-    except StopIteration:
-        yield StopIteration
+    current = next(stream)
     current_key = current.cls, current.id
     group = [current]
     for message in stream:

--- a/pokedex/db/translations.py
+++ b/pokedex/db/translations.py
@@ -28,7 +28,6 @@ import csv
 import io
 import os
 import re
-import sys
 from collections import defaultdict
 
 import six
@@ -381,10 +380,7 @@ def group_by_object(stream):
     try:
         current = next(stream)
     except StopIteration:
-        if sys.version_info >= (3, 7):
-            return
-        else:
-            raise StopIteration
+        return
     current_key = current.cls, current.id
     group = [current]
     for message in stream:

--- a/pokedex/db/translations.py
+++ b/pokedex/db/translations.py
@@ -28,6 +28,7 @@ import csv
 import io
 import os
 import re
+import sys
 from collections import defaultdict
 
 import six
@@ -377,7 +378,13 @@ def group_by_object(stream):
     Yields ((class name, object ID), (list of messages)) pairs.
     """
     stream = iter(stream)
-    current = next(stream)
+    try:
+        current = next(stream)
+    except StopIteration:
+        if sys.version_info >= (3, 7):
+            return
+        else:
+            raise StopIteration
     current_key = current.cls, current.id
     group = [current]
     for message in stream:

--- a/pokedex/db/translations.py
+++ b/pokedex/db/translations.py
@@ -377,7 +377,10 @@ def group_by_object(stream):
     Yields ((class name, object ID), (list of messages)) pairs.
     """
     stream = iter(stream)
-    current = next(stream)
+    try:
+        current = next(stream)
+    except StopIteration:
+        yield StopIteration
     current_key = current.cls, current.id
     group = [current]
     for message in stream:


### PR DESCRIPTION
In the following code:

https://github.com/veekun/pokedex/blob/18925edcd3ad71dd912a94ce4b1bc1435943937a/pokedex/db/translations.py#L374-L390

When `stream` is exhausted, operating `next(stream)` will throw `StopIteration` and the entire program will terminate. The expected behavior is `yield StopIteration` and let the for loop handle the situation.