### PR TITLE
Limit `construct` version to 2.5.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
         'SQLAlchemy>=0.9.7',
         'whoosh>=2.5,<2.7',
         'markdown',
-        'construct',
+        'construct<=2.5.3',
         'six>=1.9.0',
     ],
     entry_points = {


### PR DESCRIPTION
This project uses `construct` 2.5 and lower, and the latest `construct` version (2.9) is incompatible with 2.5.