### PR TITLE
Fix pokedex dump -l argument error (#295)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,5 @@ install: pip install -e .
 before_script: pokedex setup -v
 script:
     - py.test
-    - pokedex dump
+    - pokedex dump -l all
     - git --no-pager diff --exit-code pokedex/data/csv/

--- a/pokedex/db/load.py
+++ b/pokedex/db/load.py
@@ -431,9 +431,13 @@ def dump(session, tables=[], directory=None, verbose=False, langs=None):
         # if specified, or for official languages by default.
         # For non-translation tables, dump all rows.
         if 'local_language_id' in columns:
-            if langs is None:
+            # If no lang arguments were passed or the 'all' argument was passed
+            if langs is None or langs == ['all']:
                 def include_row(row):
                     return languages[row.local_language_id].official
+            # If the none argument is passed then nothing should be changed from the csv files
+            elif langs == ['none']:
+                return False
             elif any(col.info.get('official') for col in table.columns):
                 def include_row(row):
                     return (languages[row.local_language_id].official or

--- a/pokedex/main.py
+++ b/pokedex/main.py
@@ -114,7 +114,7 @@ def create_parser():
         help="directory to place the dumped CSV files")
     cmd_dump.add_argument(
         '-l', '--langs', dest='langs', default=None,
-        help="comma-separated list of language codes to load, 'none', or 'all' (default: en)")
+        help=u"comma-separated list of language codes to load, 'none', 'all', or other languages like 'en,es' (default: all). The 'all' and 'none' codes cannot be used with other codes.")
     cmd_dump.add_argument(
         'tables', nargs='*',
         help="list of database tables to load (default: all)")
@@ -209,6 +209,15 @@ def command_dump(parser, args):
 
     if args.langs is not None:
         langs = [l.strip() for l in args.langs.split(',')]
+        
+        # Check if either 'all' or 'none' codes are used along side other codes.
+        # If either code is used, an error message will be displayed and the progrm will close.
+        if len(langs) > 1 and 'all' in langs:
+            print("\nERROR: The 'all' code should be used by itself.")
+            return
+        elif len(langs) > 1 and 'none' in langs:
+            print("\nERROR: The 'none' code should be used by itself.")
+            return
     else:
         langs = None
 


### PR DESCRIPTION
### pokedex/main.py -
#### create_parser() -
 - Change the help message for the langs argument in the dump subparser
to show the actual default and state that the 'all' and 'none' codes
cannot be used alongside other codes.
#### command_dump() -
- Check if 'all' or 'none' codes are passed alongside other codes. If
they are, error message is printed and program ends.
---
### pokedex/db/load.py -
#### dump() -
- Add check if langs code is 'all' or 'none'.
- If langs wasn't passed to the parser or 'all' was passed (they are
the same since the default is 'all'), then everything will get
dumped to the csv files.
- If 'none' was passed to the parser, then nothing new should be
dumped to the csv files.
---
### pokexed/.travis.yml -
- Re-added 'pokedex dump -l all' that was previously remove on
77e3d9df163ac602d5c939cee75750f8be0dc725

---
Resolves: #295