### PR TITLE
Handle CLI load into existing tables gracefully

### DIFF
--- a/pokedex/db/load.py
+++ b/pokedex/db/load.py
@@ -215,12 +215,6 @@ def load(session, tables=[], directory=None, drop_tables=False, verbose=False, s
             else:
                 print("\n\n UNEXPECTED ERROR: ", error)
                 sys.exit(1)
-        
-        # In case any other exception not specified above is raised, an
-        # unexpected exception error is sent with the error included.
-        except Exception as error:
-            print("\n\nUNEXPECTED Error:  ", error)
-            sys.exit(1)
 
         print_status('%s/%s' % (n, len(table_objs)))
     print_done()

--- a/pokedex/db/load.py
+++ b/pokedex/db/load.py
@@ -207,8 +207,20 @@ def load(session, tables=[], directory=None, drop_tables=False, verbose=False, s
             if "already exists" in str(error.orig):
                 print("\n\nERROR:  The table '{}' already exists in the database. "
                     "Did you mean to use 'pokedex load -D'".format(table))
-                
+            sys.exit(1)
+
+            # If it happens to be some other error but raised by the same 
+            # exception, then an unexpected error message is sent with 
+            # the error included
+            else:
+                print("\n\n UNEXPECTED ERROR: ", error)
                 sys.exit(1)
+        
+        # In case any other exception not specified above is raised, an
+        # unexpected exception error is sent with the error included.
+        except Exception as error:
+            print("\n\nUNEXPECTED Error:  ", error)
+            sys.exit(1)
 
         print_status('%s/%s' % (n, len(table_objs)))
     print_done()

--- a/pokedex/db/load.py
+++ b/pokedex/db/load.py
@@ -207,7 +207,7 @@ def load(session, tables=[], directory=None, drop_tables=False, verbose=False, s
             if "already exists" in str(error.orig):
                 print("\n\nERROR:  The table '{}' already exists in the database. "
                     "Did you mean to use 'pokedex load -D'".format(table))
-            sys.exit(1)
+                sys.exit(1)
 
             # If it happens to be some other error but raised by the same 
             # exception, then an unexpected error message is sent with 

--- a/pokedex/db/load.py
+++ b/pokedex/db/load.py
@@ -193,7 +193,39 @@ def load(session, tables=[], directory=None, drop_tables=False, verbose=False, s
 
     print_start('Creating tables')
     for n, table in enumerate(table_objs):
-        table.create(bind=engine)
+        try:
+            table.create(bind=engine)
+        
+        # This except is for SQLite
+        except sqlalchemy.exc.OperationalError as error:
+            # All the databases create extra spaces or new lines so this is the best way I can see to handle it
+            if "table {} already exists".format(table) in error.orig.__str__():
+                print("\n\nERROR:  The table '{}' already exists in the database. "
+                    "Did you mean to use 'pokedex load -D'".format(table))
+            
+            # If the error was not that the table already exists, full error message is displayed
+            else:
+                print("\n\nUNEXPECTED Error:  ", error)
+            sys.exit(1)
+        
+        # This except is for PostgreSQL
+        except sqlalchemy.exc.ProgrammingError as error:
+            if 'relation "{}" already exists'.format(table) in error.orig.__str__():
+                print("\n\nERROR:  The table '{}' already exists in the database. "
+                    "Did you mean to use 'pokedex load -D'".format(table))
+            else:
+                print("\n\nUNEXPECTED Error:  ", error)
+            sys.exit(1)
+        
+        # This except is for MySQL
+        except sqlalchemy.exc.InternalError as error:
+            if "Table '{}' already exists".format(table) in error.orig.__str__():
+                print("\n\nERROR:  The table '{}' already exists in the database. "
+                    "Did you mean to use 'pokedex load -D'".format(table))
+            else:
+                print("\n\nUNEXPECTED Error:  ", error)
+            sys.exit(1)
+
         print_status('%s/%s' % (n, len(table_objs)))
     print_done()
 


### PR DESCRIPTION
### pokedex/db/load.py -
#### load() -
- Add exception handling for SQLite, PostgreSQL, and MySQL.
Sqlalchemy gives different exceptions for each database engine so I have
seperated each exception for each engine.
The error message passed by each engine is also different so that is
checked as well.
- Once the function gets one of those exceptions the following message
is outputed and the program ends: `ERROR:  Table 'TABLENAME' already
exists in the database. Did you mean to use 'pokedex load -D'`
- If the error is not that a table already exists, then the output will
just be the full error from sqlalchemy. That way if someone runs into
that error it can be reported as an issue and whoever can help would see
the full error.
---
Resolves part of issue #16