### PR TITLE
Fix `pokedex search` command

### DIFF
--- a/pokedex/search.py
+++ b/pokedex/search.py
@@ -46,7 +46,9 @@ def search(session, **criteria):
     do_stat = False
 
     if criteria.get('name') is not None:
-        query = query.filter(t.Pokemon.species.has(func.lower(t.PokemonSpecies.name) == criteria['name'].lower()))
+        query = query.join(t.Pokemon.species)
+        query = query.join(t.PokemonSpecies.names_local)
+        query = query.filter(func.lower(t.PokemonSpecies.names_table.name) == criteria['name'].lower())
 
     for stat_ident in (u'attack', u'defense', u'special-attack', u'special-defense', u'speed', u'hp'):
         criterion = criteria.get(stat_ident)


### PR DESCRIPTION
Filtering on pokemon name was broken. Not sure why, since the search CLI
was added way after the i18n stuff was added. The error is related to
AssociationProxy, which figures because nothing about association
proxies ever seems to work right. I don't know enough about SQLAlchemy
internals to know if what it was trying to do was supposed to
work, or how to fix it if so. So, fix it by using the same boring
join-based filtering that spline-pokedex uses.

Running `pokedex search --name=gloom` caused the following error with
PostgreSQL and SQLAlchemy 1.3.5:

    sqlalchemy.exc.ProgrammingError: (psycopg2.ProgrammingError) can't adapt type 'ColumnAssociationProxyInstance'

...and this error with SQLite.

    sqlalchemy.exc.InterfaceError: (sqlite3.InterfaceError) Error binding parameter 4 - probably unsupported type.
    [parameters: (9, 9, 9, 9, ColumnAssociationProxyInstance(AssociationProxy('names_local', 'name')), 'gloom')]

Additionaly, the following error would happen with PostgreSQL and SQLAlchemy 0.9.7,
but that's probably unrelated:

    sqlalchemy.exc.ProgrammingError: (ProgrammingError) subquery in FROM must have an alias
    LINE 4: FROM pokemon_species, (SELECT pokemon_species_names.name AS ...
                                   ^

Fixes #296