### PR TITLE
Dump language names from HOME

### DIFF
--- a/pokedex/data/csv/language_names.csv
+++ b/pokedex/data/csv/language_names.csv
@@ -1,60 +1,112 @@
 language_id,local_language_id,name
-1,1,日本語
-1,3,일본어
-1,5,Japonais
-1,6,Japanisch
-1,7,Japonés
-1,9,Japanese
+1,1,JPN（ひらがな）
+1,3,JPN(일본어/가나)
+1,4,JPN（日文假名）
+1,5,Japonais (hiragana)
+1,6,Japanisch (Hiragana)
+1,7,Japonés (hiragana)
+1,8,Giapponese (hiragana)
+1,9,Japanese (Kana)
+1,11,JPN（日本語・かな）
+1,12,JPN（日文假名）
 2,1,正式ローマジ
 2,3,정식 로마자
 2,5,Romaji
 2,6,Rōmaji
 2,9,Official roomaji
-3,1,韓国語
-3,3,한국어
+3,1,KOR（かんこくご）
+3,3,KOR(한국어)
+3,4,KOR（韓文）
 3,5,Coréen
 3,6,Koreanisch
 3,7,Coreano
+3,8,Coreano
 3,9,Korean
-4,1,中国語
-4,3,중국어
-4,5,Chinois
-4,6,Chinesisch
-4,7,Chino
-4,9,Chinese
-5,1,フランス語
-5,3,프랑스어
+3,11,KOR（韓国語）
+3,12,KOR（韩语）
+4,1,CHT（はんたいじ）
+4,3,CHT(중국어/번체자)
+4,4,CHT（繁體中文）
+4,5,Chinois traditionnel
+4,6,Chinesisch (traditionell)
+4,7,Chino tradicional
+4,8,Cinese (tradizionale)
+4,9,Chinese (Traditional)
+4,11,CHT（繁体字）
+4,12,CHT（繁体中文）
+5,1,FRA（フランスご）
+5,3,FRE(프랑스어)
+5,4,FRA（法文）
 5,5,Français
 5,6,Französisch
 5,7,Francés
+5,8,Francese
 5,9,French
-6,1,ドイツ語
-6,3,도이치어
+5,11,FRA（フランス語）
+5,12,FRA（法语）
+6,1,GER（ドイツご）
+6,3,GER(독일어)
+6,4,GER（德文）
 6,5,Allemand
 6,6,Deutsch
 6,7,Alemán
+6,8,Tedesco
 6,9,German
-7,1,西語
-7,3,스페인어
+6,11,GER（ドイツ語）
+6,12,GER（德语）
+7,1,SPA（スペインご）
+7,3,SPA(스페인어)
+7,4,SPA（西班牙文）
 7,5,Espagnol
 7,6,Spanisch
 7,7,Español
+7,8,Spagnolo
 7,9,Spanish
-8,1,伊語
-8,3,이탈리아어
+7,11,SPA（スペイン語）
+7,12,SPA（西班牙语）
+8,1,ITA（イタリアご）
+8,3,ITA(이탈리아어)
+8,4,ITA（義大利文）
 8,5,Italien
 8,6,Italienisch
 8,7,Italiano
+8,8,Italiano
 8,9,Italian
-9,1,英語
-9,3,영어
+8,11,ITA（イタリア語）
+8,12,ITA（意大利语）
+9,1,ENG（えいご）
+9,3,ENG(영어)
+9,4,ENG（英文）
 9,5,Anglais
 9,6,Englisch
 9,7,Inglés
+9,8,Inglese
 9,9,English
+9,11,ENG（英語）
+9,12,ENG（英语）
 10,1,チェコ語
 10,3,체코어
 10,5,Tchèque
 10,6,Tschechisch
 10,7,Checo
 10,9,Czech
+11,1,JPN（かんじ）
+11,3,JPN(일본어/한자)
+11,4,JPN（日文漢字）
+11,5,Japonais (kanji)
+11,6,Japanisch (Kanji)
+11,7,Japonés (kanji)
+11,8,Giapponese (kanji)
+11,9,Japanese (Kanji)
+11,11,JPN（日本語・漢字）
+11,12,JPN（日文汉字）
+12,1,CHS（かんたいじ）
+12,3,CHS(중국어/간체자)
+12,4,CHS（簡體中文）
+12,5,Chinois simplifié
+12,6,Chinesisch (vereinfacht)
+12,7,Chino simplificado
+12,8,Cinese (semplificato)
+12,9,Chinese (Simplified)
+12,11,CHS（簡体字）
+12,12,CHS（简体中文）


### PR DESCRIPTION
- Adds all the Italian, Japanese (Kanji), Chinese (Traditional) and Chinese (Simplified) translations
- Adds all the translations for Japanese (Kanji) and Chinese (Simplified)
- Updates the translations for Japanese (Kana), adding `Kana/hirigana` in parentheses
- Updates the Japanese (Kana) translations, which were prevously incorrectly using kanji - see #256

For some reason chinese, japanese and korean translations also have a 3-letter name in latin letters, but it can be easily removed if you prefer