### PR TITLE
Corrected en-us growth rate names

### DIFF
--- a/pokedex/data/csv/growth_rate_prose.csv
+++ b/pokedex/data/csv/growth_rate_prose.csv
@@ -13,7 +13,7 @@ growth_rate_id,local_language_id,name
 4,9,medium slow
 5,5,erratique
 5,6,"langsam, dann sehr schnell"
-5,9,slow then very fast
+5,9,erratic
 6,5,fluctuante
 6,6,"schnell, dann sehr langsam"
-6,9,fast then very slow
+6,9,fluctuating


### PR DESCRIPTION
Previously, the names for the `erratic` and `fluctuating` en-us growth rates were listed incorrectly.

Note that Language id 6 (German) also needs corrected by someone who speaks German.