### PR TITLE
Support SQLAlchemy 1.4

### DIFF
--- a/pokedex/db/load.py
+++ b/pokedex/db/load.py
@@ -17,7 +17,7 @@ from pokedex.defaults import get_default_csv_dir
 from pokedex.db.dependencies import find_dependent_tables
 from pokedex.db.oracle import rewrite_long_table_names
 
-from sqlalchemy import and_
+from sqlalchemy import and_, true
 from sqlalchemy.sql import exists
 
 
@@ -381,6 +381,7 @@ def load(session, tables=[], directory=None, drop_tables=False, verbose=False, s
         session.query(VGPMM).delete()
 
         q = session.query(t.VersionGroup.id, t.PokemonMoveMethod.id)
+        q = q.filter(true())  # Suppress cartesian product warning
         q = q.filter(exists().where(and_(
                 t.PokemonMove.pokemon_move_method_id == t.PokemonMoveMethod.id,
                 t.PokemonMove.version_group_id == t.VersionGroup.id)))

--- a/pokedex/db/multilang.py
+++ b/pokedex/db/multilang.py
@@ -185,6 +185,7 @@ def create_translation_table(_table_name, foreign_class, relation_name,
         foreign_keys=[Translations.foreign_id, Translations.local_language_id],
         uselist=False,
         lazy=relation_lazy,
+        viewonly=True,
     ))
 
     # Add per-column proxies to the original class

--- a/pokedex/db/multilang.py
+++ b/pokedex/db/multilang.py
@@ -10,6 +10,18 @@ from sqlalchemy.types import Integer
 
 from pokedex.db import markdown
 
+# Decide which method to use for the default value of the parameter _default_language_id
+_MULTILANG_SESSION_USE_EVENT = False
+try:
+    from sqlalchemy.orm import SessionEvents
+except ImportError:
+    pass
+else:
+    if hasattr(SessionEvents, 'do_orm_execute'):
+        # SQLAlchemy 1.4+
+        from sqlalchemy import event
+        _MULTILANG_SESSION_USE_EVENT = True
+
 class LocalAssociationProxy(AssociationProxy, ColumnOperators):
     """An association proxy for names in the default language
 
@@ -168,7 +180,7 @@ def create_translation_table(_table_name, foreign_class, relation_name,
         primaryjoin=and_(
             Translations.foreign_id == foreign_class.id,
             Translations.local_language_id == bindparam('_default_language_id',
-                value='dummy', type_=Integer, required=True),
+                value='dummy', type_=Integer),
         ),
         foreign_keys=[Translations.foreign_id, Translations.local_language_id],
         uselist=False,
@@ -206,14 +218,16 @@ def create_translation_table(_table_name, foreign_class, relation_name,
     # Done
     return Translations
 
-class MultilangQuery(Query):
-    def _execute_and_instances(self, *args, **kwargs):
-        # Set _default_language_id param if it hasn't been set by the time the query is executed.
-        # XXX This is really hacky and we should figure out a cleaner method.
-        if '_default_language_id' not in self._params or self._params['_default_language_id'] == 'dummy':
-            self._params = self._params.copy()
-            self._params['_default_language_id'] = self.session.default_language_id
-        return super(MultilangQuery, self)._execute_and_instances(*args, **kwargs)
+if not _MULTILANG_SESSION_USE_EVENT:
+    # SQLAlchemy 1.4 no longer supports Query._execute_and_instances
+    class MultilangQuery(Query):
+        def _execute_and_instances(self, *args, **kwargs):
+            # Set _default_language_id param if it hasn't been set by the time the query is executed.
+            # XXX This is really hacky and we should figure out a cleaner method.
+            if '_default_language_id' not in self._params or self._params['_default_language_id'] == 'dummy':
+                self._params = self._params.copy()
+                self._params['_default_language_id'] = self.session.default_language_id
+            return super(MultilangQuery, self)._execute_and_instances(*args, **kwargs)
 
 class MultilangSession(Session):
     """A tiny Session subclass that adds support for a default language.
@@ -232,9 +246,18 @@ class MultilangSession(Session):
 
         self.markdown_extension = markdown_extension_class(self)
 
-        kwargs.setdefault('query_cls', MultilangQuery)
+        if not _MULTILANG_SESSION_USE_EVENT:
+            kwargs.setdefault('query_cls', MultilangQuery)
 
         super(MultilangSession, self).__init__(*args, **kwargs)
+
+if _MULTILANG_SESSION_USE_EVENT:
+    @event.listens_for(MultilangSession, 'do_orm_execute')
+    def receive_do_orm_execute(state):
+        # Set _default_language_id param if it hasn't been set by the time the query is executed.
+        # The same hack as above, but for SQLAlchemy 1.4+
+        if state.is_select and state.parameters.get('_default_language_id', 'dummy') == 'dummy':
+            return state.invoke_statement(params={'_default_language_id': state.session.default_language_id})
 
 class MultilangScopedSession(ScopedSession):
     """Dispatches language selection to the attached Session."""

--- a/pokedex/db/tables.py
+++ b/pokedex/db/tables.py
@@ -2475,7 +2475,8 @@ Experience.growth_rate = relationship(GrowthRate,
 Generation.versions = relationship(Version,
     secondary=VersionGroup.__table__,
     innerjoin=True)
-Generation.main_region = relationship(Region, innerjoin=True)
+Generation.main_region = relationship(Region, innerjoin=True,
+    backref=backref('generation', uselist=False))
 
 
 GrowthRate.max_experience_obj = relationship(Experience,
@@ -2497,13 +2498,12 @@ Item.flavor_text = relationship(ItemFlavorText,
 Item.fling_effect = relationship(ItemFlingEffect,
     backref='items')
 Item.machines = relationship(Machine,
-    order_by=Machine.version_group_id.asc())
+    order_by=Machine.version_group_id.asc(),
+    backref='item')
 Item.category = relationship(ItemCategory,
     innerjoin=True,
     backref=backref('items', order_by=Item.identifier.asc()))
 Item.pocket = association_proxy('category', 'pocket')
-
-ItemCategory.pocket = relationship(ItemPocket, innerjoin=True)
 
 ItemFlavorText.version_group = relationship(VersionGroup,
     innerjoin=True, lazy='joined')
@@ -2518,7 +2518,8 @@ ItemGameIndex.generation = relationship(Generation,
 
 ItemPocket.categories = relationship(ItemCategory,
     innerjoin=True,
-    order_by=ItemCategory.identifier.asc())
+    order_by=ItemCategory.identifier.asc(),
+    backref=backref('pocket', innerjoin=True))
 
 
 Location.region = relationship(Region,
@@ -2539,11 +2540,6 @@ LocationGameIndex.location = relationship(Location,
     innerjoin=True, lazy='joined',
     backref='game_indices')
 LocationGameIndex.generation = relationship(Generation,
-    innerjoin=True, lazy='joined')
-
-
-Machine.item = relationship(Item)
-Machine.version_group = relationship(VersionGroup,
     innerjoin=True, lazy='joined')
 
 
@@ -2886,7 +2882,6 @@ PokemonSpecies.conquest_evolution = relationship(ConquestPokemonEvolution,
 PokemonSpeciesFlavorText.version = relationship(Version, innerjoin=True, lazy='joined')
 PokemonSpeciesFlavorText.language = relationship(Language, innerjoin=True, lazy='joined')
 
-Region.generation = relationship(Generation, uselist=False)
 Region.version_group_regions = relationship(VersionGroupRegion,
     order_by=VersionGroupRegion.version_group_id.asc(),
     backref='region')
@@ -2950,7 +2945,8 @@ VersionGroup.pokemon_move_methods = relationship(PokemonMoveMethod,
     backref="version_groups")
 VersionGroup.machines = relationship(Machine,
     innerjoin=True,
-    order_by=Machine.machine_number)
+    order_by=Machine.machine_number,
+    backref=backref('version_group', innerjoin=True, lazy='joined'))
 
 
 VersionGroupPokemonMoveMethod.version_group = relationship(VersionGroup,

--- a/pokedex/db/tables.py
+++ b/pokedex/db/tables.py
@@ -30,6 +30,7 @@ from functools import partial
 import six
 
 from sqlalchemy import Column, ForeignKey, MetaData, PrimaryKeyConstraint, UniqueConstraint
+from sqlalchemy import __version__ as sqla_version
 from sqlalchemy.ext.declarative import declarative_base, DeclarativeMeta
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.hybrid import hybrid_property
@@ -38,6 +39,12 @@ from sqlalchemy.sql import and_
 from sqlalchemy.types import Boolean, Enum, Integer, SmallInteger, Unicode, UnicodeText
 
 from pokedex.db import markdown, multilang
+
+relationship = partial(relationship, viewonly=True)
+if (1, 3, 17) <= tuple(int(x) for x in sqla_version.split(".")) < (1, 4):
+    # `sync_backref` was introduced in 1.3.17
+    # Since 1.4 it defaults to False if `viewonly` is True
+    relationship = partial(relationship, sync_backref=False)
 
 class TableSuperclass(object):
     """Superclass for declarative tables, to give them some generic niceties

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
         'pokedex': ['data/csv/*.csv']
     },
     install_requires=[
-        'SQLAlchemy>=1.0,<1.4',
+        'SQLAlchemy>=1.0,<2.0',
         'whoosh>=2.5,<2.7',
         'markdown>=2.4.1,<=2.6.11',
         'construct==2.5.3',


### PR DESCRIPTION
- The `do_orm_execute` event is now used to set the default value for `_default_language_id`, since the old method (subclassing `Query._execute_and_instances`) is no longer supported. The old method is still there to maintain compatibility with 1.0-1.3.
- A couple of double relationships referring to one another are now simply one relationship with `backref=True`.
- Every relationship in `pokedex/db/tables.py` now has the attribute `viewonly=True`: this is required to silence many warnings added in 1.4, and it shouldn't do any harm since as far as I know beside the setup/load/dump functions nothing writes stuff into the database, and those don't really use the ORM to do so. If the SQLAlchemy version is at least 1.3.17 but less than 1.4 `sync_backref=False` is used as well (since 1.4 it defaults to `False`).
- SQLAlchemy 1.4 now implements a warning about [potential cartesian products in select statements](https://docs.sqlalchemy.org/en/14/changelog/migration_14.html?highlight=cartesian%20product#built-in-from-linting-will-warn-for-any-potential-cartesian-products-in-a-select-statement). In `pokedex/db/load.py` there's an intentional cartesian product, adding `q = q.filter(true())` is enough to silence the warning.

Closes #330 