### PR TITLE
Update python-markdown

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 os: linux
 language: python
 python:
-    - "2.7"
     - "3.4"
     - "3.5"
     - "3.6"

--- a/pokedex/db/markdown.py
+++ b/pokedex/db/markdown.py
@@ -17,8 +17,9 @@ import re
 import markdown
 import six
 from sqlalchemy.orm.session import object_session
-from markdown.util import etree, AtomicString
 
+from markdown.util import AtomicString
+import xml.etree.ElementTree as etree 
 
 @six.python_2_unicode_compatible
 class MarkdownString(object):

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     install_requires=[
         'SQLAlchemy>=1.0,<1.4',
         'whoosh>=2.5,<2.7',
-        'markdown>=2.4.1,<=2.6.11',
+        'markdown>=3.4,<3.5',
         'construct==2.5.3',
         'six>=1.9.0',
     ],

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
     },
     classifiers=[
         "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
This PR is the same submitted to a forked repository.
https://github.com/PokeAPI/pokedex/pull/113

---------------

I'd like to run pokedex on macOS with Apple Silicon. However, the old python-markdown doesn't support building for M1 chips.

I updated python-markdown for the latest version.

    markdown.util.etree is deprecated on 3.2. According to the official documentation, use xml.etree.ElementTree instead. https://python-markdown.github.io/change_log/release-3.2/#markdownutiletree-deprecated
    latest python-markdown doesn't support ancient Pythons. So I dropped 2.7 support. Python 2.x is no longer supported officially.

